### PR TITLE
SDCLANG bringup for gemini

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -183,6 +183,8 @@ TARGET_POWERHAL_VARIANT := qcom
 BOARD_USES_QCOM_HARDWARE := true
 BOARD_USES_QC_TIME_SERVICES := true
 TARGET_USE_SDCLANG := true
+SDCLANG_PATH := prebuilts/clang/linux-x86/host/sdclang-3.8/bin
+SDCLANG_LTO_DEFS := device/qcom/common/sdllvm-lto-defs.mk
 
 # Recovery
 TARGET_RECOVERY_FSTAB := $(DEVICE_PATH)/rootdir/etc/fstab.qcom

--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -182,9 +182,12 @@ TARGET_POWERHAL_VARIANT := qcom
 # QCOM
 BOARD_USES_QCOM_HARDWARE := true
 BOARD_USES_QC_TIME_SERVICES := true
+
+ifneq ($(HOST_OS),darwin)
 TARGET_USE_SDCLANG := true
 SDCLANG_PATH := prebuilts/clang/linux-x86/host/sdclang-3.8/bin
 SDCLANG_LTO_DEFS := device/qcom/common/sdllvm-lto-defs.mk
+endif
 
 # Recovery
 TARGET_RECOVERY_FSTAB := $(DEVICE_PATH)/rootdir/etc/fstab.qcom


### PR DESCRIPTION
- Sets the SDCLANG path and location of LTO definitions, which are needed by the build system
- Guards against Darwin using SDCLANG because it only supports Linux at this time